### PR TITLE
Fix NTSC FM frequencies

### DIFF
--- a/src/midi_fm.c
+++ b/src/midi_fm.c
@@ -7,9 +7,9 @@ static const u8 MIN_MIDI_PITCH = 11;
 static const u8 MAX_MIDI_PITCH = 106;
 static const u8 SEMITONES = 12;
 static const u16 FREQS_NTSC[] = {
-    617, // B
-    653, 692, 733, 777, 823, 872, 924, 979, 1037, 1099,
-    1164 // A#
+    607, // B
+    644, 681, 722, 765, 810, 858, 910, 964, 1021, 1081,
+    1146 // A#
 };
 
 static const u16 FREQS_PAL[] = {

--- a/src/ui.c
+++ b/src/ui.c
@@ -215,7 +215,7 @@ void ui_update(void)
     }
 
     ui_fm_update();
-    SYS_doVBlankProcessEx(IMMEDIATLY);
+    SYS_doVBlankProcessEx(IMMEDIATELY);
 }
 
 static u16 load_percent(void)

--- a/tests/system/test_e2e.c
+++ b/tests/system/test_e2e.c
@@ -32,7 +32,7 @@ static void test_midi_note_on_event_sent_to_ym2612(void** state)
     stub_usb_receive_byte(noteOnVelocity);
 
     expect_ym2612_write_channel(0, 0xA4, 0x1A);
-    expect_ym2612_write_channel(0, 0xA0, 0x8D);
+    expect_ym2612_write_channel(0, 0xA0, 0x84);
 
     expect_ym2612_write_reg(0, 0x28, 0xF0);
 
@@ -60,7 +60,7 @@ static void test_polyphonic_midi_sent_to_separate_ym2612_channels(void** state)
     stub_usb_receive_byte(noteOnVelocity);
 
     expect_ym2612_write_channel(0, 0xA4, 0x1A);
-    expect_ym2612_write_channel(0, 0xA0, 0x8D);
+    expect_ym2612_write_channel(0, 0xA0, 0x84);
     expect_ym2612_write_reg(0, 0x28, 0xF0);
 
     midi_receiver_read();
@@ -70,7 +70,7 @@ static void test_polyphonic_midi_sent_to_separate_ym2612_channels(void** state)
     stub_usb_receive_byte(noteOnVelocity);
 
     expect_ym2612_write_channel(1, 0xA4, 0x1A);
-    expect_ym2612_write_channel(1, 0xA0, 0xB4);
+    expect_ym2612_write_channel(1, 0xA0, 0xA9);
     expect_ym2612_write_reg(0, 0x28, 0xF1);
 
     midi_receiver_read();
@@ -123,7 +123,7 @@ static void test_general_midi_reset_sysex_stops_all_notes(void** state)
     stub_usb_receive_byte(noteOnVelocity);
 
     expect_ym2612_write_channel(0, 0xA4, 0x1A);
-    expect_ym2612_write_channel(0, 0xA0, 0x8D);
+    expect_ym2612_write_channel(0, 0xA0, 0x84);
     expect_ym2612_write_reg(0, 0x28, 0xF0);
 
     midi_receiver_read();

--- a/tests/unit/test_midi.h
+++ b/tests/unit/test_midi.h
@@ -18,8 +18,8 @@
 #define TONE_NTSC_DS4 380
 #define TONE_NTSC_A2 1016
 
-#define SYNTH_NTSC_C 653
-#define SYNTH_NTSC_AS 1164
+#define SYNTH_NTSC_C 644
+#define SYNTH_NTSC_AS 1146
 #define SYNTH_PAL_C 649
 
 #define SYSEX_DYNAMIC_AUTO 0x02

--- a/tests/unit/test_midi_dynamic.c
+++ b/tests/unit/test_midi_dynamic.c
@@ -30,7 +30,7 @@ static int test_dynamic_midi_setup(UNUSED void** state)
 static void test_midi_dynamic_uses_all_channels(UNUSED void** state)
 {
     const u8 octave = 4;
-    const u16 freq = 0x28d;
+    const u16 freq = 0x284;
     const u16 pitch = 60;
 
     print_message("FM channels...\n");
@@ -59,13 +59,13 @@ static void test_midi_routing_switches_to_dynamic_on_gm_reset(
         sysExGeneralMidiResetSequence, sizeof(sysExGeneralMidiResetSequence));
 
     print_message("Initial note");
-    expect_synth_pitch(0, 4, 0x28d);
+    expect_synth_pitch(0, 4, 0x284);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 0);
     __real_midi_note_on(0, 60, MAX_MIDI_VOLUME);
 
     print_message("Second note");
-    expect_synth_pitch(1, 4, 0x2b4);
+    expect_synth_pitch(1, 4, 0x2a9);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 1);
     __real_midi_note_on(0, 61, MAX_MIDI_VOLUME);
@@ -75,7 +75,7 @@ static void test_midi_dynamic_tries_to_reuse_original_midi_channel_if_available(
     UNUSED void** state)
 {
     const u8 octave = 4;
-    const u16 freq = 0x28d;
+    const u16 freq = 0x284;
     const u16 pitch = 60;
 
     for (u8 chan = 0; chan < 3; chan++) {
@@ -116,7 +116,7 @@ test_midi_dynamic_reuses_mapped_midi_channel_even_if_busy_if_sticking_to_device_
         __real_midi_note_on(REUSE_MIDI_CHANNEL, pitch, MAX_MIDI_VOLUME);
     }
 
-    expect_synth_pitch(0, 6, 0x48c);
+    expect_synth_pitch(0, 6, 0x47a);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 0);
     __real_midi_note_on(REUSE_MIDI_CHANNEL, MIDI_PITCH_AS6, MAX_MIDI_VOLUME);
@@ -232,7 +232,7 @@ static void test_midi_sysex_resets_dynamic_mode_state(UNUSED void** state)
 {
     const u8 sysExGeneralMidiResetSequence[] = { 0x7E, 0x7F, 0x09, 0x01 };
     const u8 octave = 4;
-    const u16 freq = 0x28d;
+    const u16 freq = 0x284;
     const u16 pitch = 60;
 
     for (u16 i = DEV_CHAN_MIN_FM; i <= DEV_CHAN_MAX_FM; i++) {
@@ -394,7 +394,7 @@ static void test_midi_dynamic_maintains_pitch_bend_on_remapping(
 
     const u16 midi_bend = 0x3000;
 
-    expect_synth_pitch(0, 6, 0x48c);
+    expect_synth_pitch(0, 6, 0x47a);
     expect_synth_volume(0, MAX_MIDI_VOLUME);
     expect_value(__wrap_synth_noteOn, channel, 0);
 
@@ -402,12 +402,12 @@ static void test_midi_dynamic_maintains_pitch_bend_on_remapping(
     __real_midi_note_on(0, MIDI_PITCH_AS6, MAX_MIDI_VOLUME);
 
     print_message("Setting bend\n");
-    expect_synth_pitch(0, 6, 0x4c2);
+    expect_synth_pitch(0, 6, 0x4b0);
     __real_midi_pitch_bend(0, midi_bend);
 
-    expect_synth_pitch(1, 7, 0x29f);
+    expect_synth_pitch(1, 7, 0x295);
     expect_synth_pitch(1, 7,
-        0x269); // defaults back as pitch bend not taken into consideration on
+        0x25f); // defaults back as pitch bend not taken into consideration on
     // note on
     expect_synth_volume(1, MAX_MIDI_VOLUME);
     expect_value(__wrap_synth_noteOn, channel, 1);
@@ -558,7 +558,7 @@ static void test_midi_dynamic_sticks_to_assigned_device_type_for_midi_channels(
         __real_midi_note_on(REUSE_MIDI_CHANNEL, pitch, MAX_MIDI_VOLUME);
     }
 
-    expect_synth_pitch(0, 6, 0x48c);
+    expect_synth_pitch(0, 6, 0x47a);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 0);
     __real_midi_note_on(REUSE_MIDI_CHANNEL, MIDI_PITCH_AS6, MAX_MIDI_VOLUME);

--- a/tests/unit/test_midi_fm.c
+++ b/tests/unit/test_midi_fm.c
@@ -72,7 +72,7 @@ static void test_midi_triggers_synth_note_on_boundary_values(
     UNUSED void** state)
 {
     const u8 keys[] = { 11, 106 };
-    const u16 expectedFrequencies[] = { 617, SYNTH_NTSC_AS };
+    const u16 expectedFrequencies[] = { 607, SYNTH_NTSC_AS };
     const u8 expectedOctaves[] = { 0, 7 };
 
     for (int index = 0; index < 2; index++) {
@@ -472,7 +472,7 @@ static void test_midi_sets_synth_pitch_bend(UNUSED void** state)
         expect_value(__wrap_synth_noteOn, channel, chan);
         __real_midi_note_on(chan, 60, MAX_MIDI_VOLUME);
 
-        expect_synth_pitch(chan, 4, 0x22e);
+        expect_synth_pitch(chan, 4, 0x225);
         __real_midi_pitch_bend(chan, 1000);
     }
 }
@@ -505,7 +505,7 @@ static void test_midi_fm_note_on_percussion_channel_sets_percussion_preset(
         sizeof(P_BANK_0_INST_30_CASTANETS));
 
     expect_synth_volume_any();
-    expect_synth_pitch(FM_CHANNEL, 0, 0x337);
+    expect_synth_pitch(FM_CHANNEL, 0, 0x32a);
     expect_value(__wrap_synth_noteOn, channel, FM_CHANNEL);
 
     __real_midi_note_on(MIDI_PERCUSSION_CHANNEL, MIDI_KEY, MAX_MIDI_VOLUME);

--- a/tests/unit/test_midi_polyphony.c
+++ b/tests/unit/test_midi_polyphony.c
@@ -53,7 +53,7 @@ static void test_midi_polyphonic_mode_uses_multiple_fm_channels(
 
         __real_midi_note_on(chan, MIDI_PITCH_AS6, MAX_MIDI_VOLUME);
 
-        expect_synth_pitch(1, 7, 0x269);
+        expect_synth_pitch(1, 7, 0x25f);
         expect_synth_volume_any();
         expect_value(__wrap_synth_noteOn, channel, 1);
 

--- a/tests/unit/test_midi_sysex.c
+++ b/tests/unit/test_midi_sysex.c
@@ -139,13 +139,13 @@ static void test_midi_sysex_enables_dynamic_channel_mode(UNUSED void** state)
     __real_midi_sysex(sequence, sizeof(sequence));
 
     print_message("Initial note");
-    expect_synth_pitch(0, 4, 0x28d);
+    expect_synth_pitch(0, 4, 0x284);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 0);
     __real_midi_note_on(0, 60, MAX_MIDI_VOLUME);
 
     print_message("Second note");
-    expect_synth_pitch(1, 4, 0x2b4);
+    expect_synth_pitch(1, 4, 0x2a9);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 1);
     __real_midi_note_on(0, 61, MAX_MIDI_VOLUME);
@@ -168,13 +168,13 @@ static void test_midi_sysex_sets_mapping_mode_to_auto(UNUSED void** state)
         sysExGeneralMidiResetSequence, sizeof(sysExGeneralMidiResetSequence));
 
     print_message("Initial note");
-    expect_synth_pitch(0, 4, 0x28d);
+    expect_synth_pitch(0, 4, 0x284);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 0);
     __real_midi_note_on(0, 60, MAX_MIDI_VOLUME);
 
     print_message("Second note");
-    expect_synth_pitch(1, 4, 0x2b4);
+    expect_synth_pitch(1, 4, 0x2a9);
     expect_synth_volume_any();
     expect_value(__wrap_synth_noteOn, channel, 1);
     __real_midi_note_on(0, 61, MAX_MIDI_VOLUME);

--- a/tests/unit/test_synth.c
+++ b/tests/unit/test_synth.c
@@ -104,7 +104,7 @@ static void test_synth_sets_octave_and_freq_reg_chan(UNUSED void** state)
 {
     for (u8 chan = 0; chan < MAX_FM_CHANS; chan++) {
         expect_ym2612_write_channel(chan, 0xA4, 0x22);
-        expect_ym2612_write_channel(chan, 0xA0, 0x8D);
+        expect_ym2612_write_channel(chan, 0xA0, 0x84);
         __real_synth_pitch(chan, 4, SYNTH_NTSC_C);
     }
 }


### PR DESCRIPTION
Testing on my NTSC Genesis, the pitches were off for FM voices (but fine for PSG). Tried out the frequencies from [here](https://plutiedev.com/ym2612-registers) and things were in tune.