### PR TITLE
Update link to GenMDM manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Control the Yamaha YM2612 and PSG of the Sega Mega Drive via MIDI.
   - [Mega EverDrive PRO](https://krikzz.com/store/home/59-mega-everdrive-pro.html) USB port.
   - [Controller port via custom USB serial cable](https://github.com/rhargreaves/mega-drive-serial-port#hardware).
   - [MegaWiFi cartridge / BlastEm emulator](https://github.com/rhargreaves/mega-drive-midi-interface/wiki/BlastEm-&-MegaWiFi-Guide) (experimental)
-  - Control of YM2612 registers via [GenMDM-style CCs](https://catskullelectronics.com/public/genMDM.pdf)
+  - Control of YM2612 registers via [GenMDM-style CCs](https://catskullelectronics.com/pages/genmdm-manual)
 
 ## Getting Started
 


### PR DESCRIPTION
Catskull appears to have done some reorganizing. A bunch of their links were broken, but it looks like the new owner has cleaned things up.

This is simply a readme update, no code has been altered.