### PR TITLE
fix(docker-make): create out/ folder before building as root

### DIFF
--- a/docker-make
+++ b/docker-make
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+mkdir -p out
 export BUILD=$(git describe --tags --abbrev=0)
 utils/docker-run make "$@"
 echo $BUILD > out/version.txt


### PR DESCRIPTION
Hi!
Thanks for this great project :)

This is just a very small PR to prevent a `permission denied` error occuring when running `docker-make` as a non-root user.
```
./docker-make: line 6: out/version.txt: Permission denied
```

The `version.txt` file is populated outside the container in the `docker-make` script running with our current user which may not be `root`. 
Since the `out/` directory is created inside the container with `USER root` / UID 0, it will by prevent other users to write in this directory because of the default umask in the container.

A proper way to fix this would have been to run the container with current system user, but there is a less intrusive, super simple fix for this: create the `out/` folder outside the container before populating it.

Sorry for this very anecdotal PR, let's say it was a way to say "hello" :')
Now it's done, can't wait to try this awesome project of yours!

Cheers